### PR TITLE
adding a new entity

### DIFF
--- a/precipitation/ngsild-payloads/Groundwater.json
+++ b/precipitation/ngsild-payloads/Groundwater.json
@@ -9,7 +9,7 @@
             "object": "urn:ngsi-ld:Device:Station09995X0028/F"
          },
          "value": 0.0,
-         "unitCode": "MQS",
+         "unitCode": "MTR",
          "observedAt": "2020-12-01T00:00:00Z",
          "datasetId": "urn:ngsi-ld:Dataset:waterLevel:MM:09995X0028/F"
       }
@@ -22,7 +22,7 @@
             "object": "urn:ngsi-ld:Device:Station09995X0028/F"
          },
          "value": 0.0,
-         "unitCode": "MM",
+         "unitCode": "MTR",
          "observedAt": "2020-12-01T00:00:00Z",
          "datasetId": "urn:ngsi-ld:Dataset:depth:MM:09995X0028/F"
       }

--- a/precipitation/ngsild-payloads/Groundwater.json
+++ b/precipitation/ngsild-payloads/Groundwater.json
@@ -1,0 +1,31 @@
+{
+   "id": "urn:ngsi-ld:Groundwater:Pegomas",
+   "type": "Groundwater",
+   "waterLevel": [
+      {
+         "type": "Property",
+         "observedBy": {
+            "type": "Relationship",
+            "object": "urn:ngsi-ld:Device:Station09995X0028/F"
+         },
+         "value": 0.0,
+         "unitCode": "MQS",
+         "observedAt": "2020-12-01T00:00:00Z",
+         "datasetId": "urn:ngsi-ld:Dataset:waterLevel:MM:09995X0028/F"
+      }
+   ],
+   "depth": [
+      {
+         "type": "Property",
+         "observedBy": {
+            "type": "Relationship",
+            "object": "urn:ngsi-ld:Device:Station09995X0028/F"
+         },
+         "value": 0.0,
+         "unitCode": "MM",
+         "observedAt": "2020-12-01T00:00:00Z",
+         "datasetId": "urn:ngsi-ld:Dataset:depth:MM:09995X0028/F"
+      }
+   ],
+   "@context": "https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/precipitation/jsonld-contexts/precipitationCompouned.jsonld"
+}


### PR DESCRIPTION
depth represent the depth of the groundwater. It's a timeserie depending on the waterlevel so its value change over time
depth property exists in the smart data model so no need to add it to the context

and the Device:Station already exist (used for the River entity), it will permit to include the lat/lon values of the station