### PR TITLE
WithdrawalAPI

### DIFF
--- a/precipitation/ngsild-payloads/Ouvrage.json
+++ b/precipitation/ngsild-payloads/Ouvrage.json
@@ -3,12 +3,12 @@
     "type": "Structure",
     "stationCode": {
         "type": "Property",
-        "refCity": {
+        "value": "OPR0000144308"
+    },    
+    "refCity": {
             "type": "Relationship",
             "object": "urn:ngsi-ld:City:Mons"
-         },
-        "value": "OPR0000144308"
-    },
+     }
     "town": {
         "type": "Property",
         "value": "Mons"

--- a/precipitation/ngsild-payloads/Ouvrage.json
+++ b/precipitation/ngsild-payloads/Ouvrage.json
@@ -1,11 +1,15 @@
 {
-    "id": "urn:ngsi-ld:Device:OuvrageOPR0000144308",
-    "type": "Device",
+    "id": "urn:ngsi-ld:Structure:OPR0000144308",
+    "type": "Structure",
     "stationCode": {
         "type": "Property",
+        "refCity": {
+            "type": "Relationship",
+            "object": "urn:ngsi-ld:City:Mons"
+         },
         "value": "OPR0000144308"
     },
-    "commune": {
+    "town": {
         "type": "Property",
         "value": "Mons"
     },
@@ -13,7 +17,7 @@
         "type": "Property",
         "value": "SOURCE DE LA SIAGNE"
     },
-    "departement": {
+    "state": {
         "type": "Property",
         "value": "83"
     },
@@ -25,7 +29,8 @@
                 43.589577424,
                 6.92766681
             ]
-        },  
+        } 
+    },
         "@context": [
             "https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/precipitation/jsonld-contexts/precipitationCompouned.jsonld"
         ]

--- a/precipitation/ngsild-payloads/Ouvrage.json
+++ b/precipitation/ngsild-payloads/Ouvrage.json
@@ -1,0 +1,32 @@
+{
+    "id": "urn:ngsi-ld:Device:OuvrageOPR0000144308",
+    "type": "Device",
+    "stationCode": {
+        "type": "Property",
+        "value": "OPR0000144308"
+    },
+    "commune": {
+        "type": "Property",
+        "value": "Mons"
+    },
+    "name": {
+        "type": "Property",
+        "value": "SOURCE DE LA SIAGNE"
+    },
+    "departement": {
+        "type": "Property",
+        "value": "83"
+    },
+    "location": {
+        "type": "GeoProperty",
+        "value": {
+            "type": "Point",
+            "coodinates": [
+                43.589577424,
+                6.92766681
+            ]
+        },  
+        "@context": [
+            "https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/precipitation/jsonld-contexts/precipitationCompouned.jsonld"
+        ]
+    }

--- a/precipitation/ngsild-payloads/withdrawal.json
+++ b/precipitation/ngsild-payloads/withdrawal.json
@@ -1,0 +1,53 @@
+{
+    "id": "urn:ngsi-ld:WaterWithdrawal:City",
+    "type": "Withdrawal",
+    "withdrawal": [
+        {
+           "type": "Property",
+           "observedBy": {
+              "type": "Relationship",
+              "object": "urn:ngsi-ld:Device:OuvrageOPR0000144308"
+           },
+           "value": 0.0,
+           "observedAt": "2020-12-01T00:00:00Z",
+           "datasetId": "urn:ngsi-ld:Dataset:withdrawal:LTR:OPR0000144308"
+        }
+     ],
+     "withdrawalObtentionMode": [
+        {
+           "type": "Property",
+           "observedBy": {
+              "type": "Relationship",
+              "object": "urn:ngsi-ld:Device:OuvrageOPR0000144308"
+           },
+           "value": "Volume Forfaitaire",
+           "observedAt": "2020-12-01T00:00:00Z",
+           "datasetId": "urn:ngsi-ld:Dataset:withdrawal:LTR:OPR0000144308"
+        }
+     ],
+     "waterUse": [
+        {
+           "type": "Property",
+           "observedBy": {
+              "type": "Relationship",
+              "object": "urn:ngsi-ld:Device:OuvrageOPR0000144308"
+           },
+           "value": "IRR",
+           "observedAt": "2020-12-01T00:00:00Z",
+           "datasetId": "urn:ngsi-ld:Dataset:withdrawal:LTR:OPR0000144308"
+        }
+     ],
+     "withdrawalQualification": [
+        {
+           "type": "Property",
+           "observedBy": {
+              "type": "Relationship",
+              "object": "urn:ngsi-ld:Device:OuvrageOPR0000144308"
+           },
+           "value": "Correcte",
+           "observedAt": "2020-12-01T00:00:00Z",
+           "datasetId": "urn:ngsi-ld:Dataset:withdrawal:LTR:OPR0000144308"
+        }
+     ],
+    "@context": "https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/precipitation/jsonld-contexts/precipitationCompouned.jsonld"
+ }

--- a/precipitation/ngsild-payloads/withdrawal.json
+++ b/precipitation/ngsild-payloads/withdrawal.json
@@ -1,48 +1,47 @@
 {
     "id": "urn:ngsi-ld:WaterWithdrawal:City",
-    "type": "Withdrawal",
+    "type": "WaterWithdrawal",
     "withdrawal": [
         {
            "type": "Property",
            "observedBy": {
               "type": "Relationship",
-              "object": "urn:ngsi-ld:Device:OuvrageOPR0000144308"
+              "object": "urn:ngsi-ld:Structure:OPR0000144308"
            },
            "value": 0.0,
            "observedAt": "2020-12-01T00:00:00Z",
-        }
-     ],
-     "withdrawalObtentionMode": [
+           "datasetId": "urn:ngsi-ld:Dataset:Volume:LTR:APIX"
+        },
         {
-           "type": "Property",
-           "observedBy": {
-              "type": "Relationship",
-              "object": "urn:ngsi-ld:Device:OuvrageOPR0000144308"
-           },
-           "value": "Volume Forfaitaire",
-           "observedAt": "2020-12-01T00:00:00Z",
-        }
+         "type": "Property",
+         "observedBy": {
+            "type": "Relationship",
+            "object": "urn:ngsi-ld:Structure:OPR0000144308"
+         },
+         "value": "Correcte",
+         "observedAt": "2020-12-01T00:00:00Z",
+         "datasetId": "urn:ngsi-ld:Dataset:WithdrawalQualification:APIX"
+      },
+      {
+         "type": "Property",
+         "observedBy": {
+            "type": "Relationship",
+            "object": "urn:ngsi-ld:Structure:OPR0000144308"
+         },
+         "value": "Volume Forfaitaire",
+         "observedAt": "2020-12-01T00:00:00Z",
+         "datasetId": "urn:ngsi-ld:Dataset:WithdrawalType:APIX"
+      }
      ],
      "waterUse": [
         {
            "type": "Property",
            "observedBy": {
               "type": "Relationship",
-              "object": "urn:ngsi-ld:Device:OuvrageOPR0000144308"
+              "object": "urn:ngsi-ld:Structure:OPR0000144308"
            },
            "value": "IRR",
-           "observedAt": "2020-12-01T00:00:00Z",
-        }
-     ],
-     "withdrawalQualification": [
-        {
-           "type": "Property",
-           "observedBy": {
-              "type": "Relationship",
-              "object": "urn:ngsi-ld:Device:OuvrageOPR0000144308"
-           },
-           "value": "Correcte",
-           "observedAt": "2020-12-01T00:00:00Z",
+           "observedAt": "2020-12-01T00:00:00Z"
         }
      ],
     "@context": "https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/precipitation/jsonld-contexts/precipitationCompouned.jsonld"

--- a/precipitation/ngsild-payloads/withdrawal.json
+++ b/precipitation/ngsild-payloads/withdrawal.json
@@ -10,7 +10,6 @@
            },
            "value": 0.0,
            "observedAt": "2020-12-01T00:00:00Z",
-           "datasetId": "urn:ngsi-ld:Dataset:withdrawal:LTR:OPR0000144308"
         }
      ],
      "withdrawalObtentionMode": [
@@ -22,7 +21,6 @@
            },
            "value": "Volume Forfaitaire",
            "observedAt": "2020-12-01T00:00:00Z",
-           "datasetId": "urn:ngsi-ld:Dataset:withdrawal:LTR:OPR0000144308"
         }
      ],
      "waterUse": [
@@ -34,7 +32,6 @@
            },
            "value": "IRR",
            "observedAt": "2020-12-01T00:00:00Z",
-           "datasetId": "urn:ngsi-ld:Dataset:withdrawal:LTR:OPR0000144308"
         }
      ],
      "withdrawalQualification": [
@@ -46,7 +43,6 @@
            },
            "value": "Correcte",
            "observedAt": "2020-12-01T00:00:00Z",
-           "datasetId": "urn:ngsi-ld:Dataset:withdrawal:LTR:OPR0000144308"
         }
      ],
     "@context": "https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/precipitation/jsonld-contexts/precipitationCompouned.jsonld"


### PR DESCRIPTION
New API about water withdrawal for each hydraulic structure of every cities on the Siagne's watershed
informations about the : volume taken every year, the use of the water and the qualification of the withdrawal
Each withdrawal is associated to a city and a city is associated to one or many withdrawals structure (ouvrage). 

(I'll update the ContextCompound when the both structure of withdrawal and Device:Ouvrage will be appoved)