### PR TITLE
update ccontext with AgriCropRecord. Fix agriParcel example.

### DIFF
--- a/agriMushroom/jsonld-contexts/agri-mushroom.jsonld
+++ b/agriMushroom/jsonld-contexts/agri-mushroom.jsonld
@@ -3,6 +3,7 @@
         "seededAt": "https://uri.fiware.org/ns/data-models#seededAt",
         "spawn": "https://uri.fiware.org/ns/data-models#spawn",
         "harvestWeight": "https://uri.fiware.org/ns/data-models#harvestWeight",
+        "AgriCropRecord": "https://uri.fiware.org/ns/data-models#AgriCropRecord",
         "hasAgriCropRecord": "https://uri.fiware.org/ns/data-models#hasAgriCropRecord"
     }
 }

--- a/agriMushroom/ngsild-payloads/agriParcel.json
+++ b/agriMushroom/ngsild-payloads/agriParcel.json
@@ -11,11 +11,11 @@
             ]
         }
     },
-    "cropStatus": {
+    "https://uri.fiware.org/ns/data-models#cropStatus": {
         "type": "Property",
         "value": "seeded"
     },
-    "lastPlantedAt": {
+    "https://uri.fiware.org/ns/data-models#lastPlantedAt": {
         "type": "Property",
         "value": "2020-01-25T00:00:00+01:00"
     },


### PR DESCRIPTION
Context was missing for AgriCropRecord.
agriParcel example was wrong (missing expanded context for lastPlantedAt and cropStatus).