### PR TITLE
add payload example for new AgriParcelRecord entity

### DIFF
--- a/agriMushroom/ngsild-payloads/agriParcelRecord.json
+++ b/agriMushroom/ngsild-payloads/agriParcelRecord.json
@@ -7,14 +7,22 @@
             "value": 0.3,
             "observedAt": "2021-10-12T10:49:26.450113+02:00",
             "unitCode": "P1",
-            "datasetid": "urn:dev:qai:elsys:ers02:lora:a81758fffe06317e:"
+            "datasetid": "urn:ngsi-ld:Dataset:elsys:01:relativeHumidity",
+            "observedBy": {
+                "type": "Relationship",
+                "object": "urn:ngsi-ld:Device:elsys:ers02:lora:a81758fffe06317d"
+            }
         },
         {
             "type": "Property",
             "value": 0.35,
             "observedAt": "2021-10-12T10:49:26.450113+02:00",
             "unitCode": "P1",
-            "datasetid": "urn:dev:qai:elsys:ers02:lora:a81758fffe06317d:"
+            "datasetid": "urn:ngsi-ld:Dataset:elsys:02:relativeHumidity",
+            "observedBy": {
+                "type": "Relationship",
+                "object": "urn:ngsi-ld:Device:elsys:ers02:lora:a81758fffe06317e"
+            }
         }
     ],
     "temperature": [
@@ -23,14 +31,22 @@
             "value": 17.2,
             "observedAt": "2021-10-12T10:49:26.450113+02:00",
             "unitCode": "CEL",
-            "datasetid": "urn:dev:qai:elsys:ers02:lora:a81758fffe06317e:"
+            "datasetid": "urn:ngsi-ld:Dataset:elsys:01:temperature",
+            "observedBy": {
+                "type": "Relationship",
+                "object": "urn:ngsi-ld:Device:elsys:ers02:lora:a81758fffe06317d"
+            }
         },
         {
             "type": "Property",
             "value": 15.9,
             "observedAt": "2021-10-12T10:49:26.450113+02:00",
             "unitCode": "CEL",
-            "datasetid": "urn:dev:qai:elsys:ers02:lora:a81758fffe06317d:"
+            "datasetid": "urn:ngsi-ld:Dataset:elsys:02:temperature",
+            "observedBy": {
+                "type": "Relationship",
+                "object": "urn:ngsi-ld:Device:elsys:ers02:lora:a81758fffe06317e"
+            }
         }
     ],
     "co2": [
@@ -39,14 +55,22 @@
             "value": 444,
             "observedAt": "2021-10-12T10:49:26.450113+02:00",
             "unitCode": "59",
-            "datasetid": "urn:dev:qai:elsys:ers02:lora:a81758fffe06317e:"
+            "datasetid": "urn:ngsi-ld:Dataset:elsys:01:co2",
+            "observedBy": {
+                "type": "Relationship",
+                "object": "urn:ngsi-ld:Device:elsys:ers02:lora:a81758fffe06317d"
+            }
         },
         {
             "type": "Property",
             "value": 555,
             "observedAt": "2021-10-12T10:49:26.450113+02:00",
             "unitCode": "59",
-            "datasetid": "urn:dev:qai:elsys:ers02:lora:a81758fffe06317d:"
+            "datasetid": "urn:ngsi-ld:Dataset:elsys:02:co2",
+            "observedBy": {
+                "type": "Relationship",
+                "object": "urn:ngsi-ld:Device:elsys:ers02:lora:a81758fffe06317e"
+            }
         }
     ],
     "hasAgriParcel": {

--- a/agriMushroom/ngsild-payloads/deviceElsys.json
+++ b/agriMushroom/ngsild-payloads/deviceElsys.json
@@ -1,0 +1,37 @@
+{
+    "id": "urn:ngsi-ld:Device:elsys:ers02:lora:a81758fffe06317e",
+    "type": "Device",
+    "controlledAssest": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:AgriParcel:Pilze:locationName"
+    },
+    "controlledProperty": {
+        "type": "Property",
+        "value": [
+            "relativeHumidity",
+            "temperature",
+            "co2"
+        ]
+    },
+    "serialNumber": {
+        "type": "Property",
+        "value": "a81758fffe06317e"
+    },
+    "dateInstalled": {
+        "type": "Property",
+        "value": "2021-11-30T11:00:00Z"
+    },
+    "location": {
+        "type": "GeoProperty",
+        "value": {
+            "type": "Point",
+            "coordinates": [
+                0.0,
+                0.0
+            ]
+        }
+    },
+    "@context": [
+        "https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/agriMushroom/jsonld-contexts/agri-mushroom-compound.jsonld"
+    ]
+}


### PR DESCRIPTION
A payload example for the new AgriParcelRecord has been added.

resolve #73 