### PR TITLE
add contexts for weather information

### DIFF
--- a/weather/jsonld-contexts/README.md
+++ b/weather/jsonld-contexts/README.md
@@ -1,0 +1,7 @@
+# Context files for weather
+Contains:
+* context file from smartdata models **dataModel.Environment** for `co2` (https://raw.githubusercontent.com/smart-data-models/dataModel.Environment/master/context.jsonld)
+* context files from smartdata models **dataModel.Weather** for most of the weather observed properties, e.g. `relativeHumidity`, `temperature`, etc. (https://raw.githubusercontent.com/smart-data-models/dataModel.Weather/master/context.jsonld)
+* a custom weather.jsonld file that contains properties not present in **dataModel.Weather**, e.g. `cloud`, `precipitationIntensity` (https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/weather/jsonld-contexts/weather.jsonld).
+
+    *pull request to be created on smartdata model to add these properties.*

--- a/weather/jsonld-contexts/weather-compound.jsonld
+++ b/weather/jsonld-contexts/weather-compound.jsonld
@@ -1,7 +1,8 @@
 {
     "@context": [
         "https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/weather/jsonld-contexts/weather.jsonld",
-        "https://fiware.github.io/data-models/context.jsonld",
+        "https://raw.githubusercontent.com/smart-data-models/dataModel.Environment/master/context.jsonld",
+        "https://raw.githubusercontent.com/smart-data-models/dataModel.Weather/master/context.jsonld",
         "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ]
 }

--- a/weather/jsonld-contexts/weather-compound.jsonld
+++ b/weather/jsonld-contexts/weather-compound.jsonld
@@ -1,0 +1,7 @@
+{
+    "@context": [
+        "https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/weather/jsonld-contexts/weather.jsonld",
+        "https://fiware.github.io/data-models/context.jsonld",
+        "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
+    ]
+}

--- a/weather/jsonld-contexts/weather.jsonld
+++ b/weather/jsonld-contexts/weather.jsonld
@@ -4,7 +4,7 @@
         "cloud": "https://uri.fiware.org/ns/data-models#cloud",
         "visibility": "https://uri.fiware.org/ns/data-models#visibility",
         "precipitationIntensity": "https://uri.fiware.org/ns/data-models#precipitationIntensity",
-        "relativeHumidity90": "https://uri.fiware.org/ns/data-models#relativeHumidity90",
-        "relativeHumidity80": "https://uri.fiware.org/ns/data-models#relativeHumidity80"
+        "relativeHumidityOverThreshold": "https://uri.fiware.org/ns/data-models#relativeHumidityOverThreshold",
+        "windMaxAverage": "https://uri.fiware.org/ns/data-models#windMaxAverage"
     }
 }

--- a/weather/jsonld-contexts/weather.jsonld
+++ b/weather/jsonld-contexts/weather.jsonld
@@ -1,0 +1,10 @@
+{
+    "@context": {
+        "observedBy": "https://uri.fiware.org/ns/data-models#observedBy",
+        "cloud": "https://uri.fiware.org/ns/data-models#cloud",
+        "visibility": "https://uri.fiware.org/ns/data-models#visibility",
+        "precipitationIntensity": "https://uri.fiware.org/ns/data-models#precipitationIntensity",
+        "relativeHumidity90": "https://uri.fiware.org/ns/data-models#relativeHumidity90",
+        "relativeHumidity80": "https://uri.fiware.org/ns/data-models#relativeHumidity80"
+    }
+}

--- a/weather/ngsild-payloads/weatherObserved-multiple-sources
+++ b/weather/ngsild-payloads/weatherObserved-multiple-sources
@@ -1,0 +1,248 @@
+{
+  "id": "urn:ngsi-ld:WeatherObserved:Italy:Calabria:Lappano",
+  "type": "WeatherObserved",
+  "precipitationIntensity": {
+    "type": "Property",
+    "datasetId": "urn:ngsi-ld:Dataset:WeatherStation",
+    "observedBy": {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:Device:WeatherStation:dc94e9f5-6e3a-443d-88b4-778d2519b3c6"
+    },
+    "value": 12,
+    "observedAt": "2022-01-05T23:00:00Z",
+    "unitCode": "E92"
+  },
+  "relativeHumidity80": {
+    "type": "Property",
+    "datasetId": "urn:ngsi-ld:Dataset:WeatherStation",
+    "observedBy": {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:Device:WeatherStation:dc94e9f5-6e3a-443d-88b4-778d2519b3c6"
+    },
+    "value": 180,
+    "observedAt": "2022-01-05T23:00:00Z",
+    "unitCode": "SEC"
+  },
+  "relativeHumidity90": {
+    "type": "Property",
+    "datasetId": "urn:ngsi-ld:Dataset:WeatherStation",
+    "observedBy": {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:Device:WeatherStation:dc94e9f5-6e3a-443d-88b4-778d2519b3c6"
+    },
+    "value": 144,
+    "observedAt": "2022-01-05T23:00:00Z",
+    "unitCode": "SEC"
+  },
+  "windAverage1mn": {
+    "type": "Property",
+    "datasetId": "urn:ngsi-ld:Dataset:WeatherStation",
+    "observedBy": {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:Device:WeatherStation:dc94e9f5-6e3a-443d-88b4-778d2519b3c6"
+    },
+    "value": 0,
+    "observedAt": "2022-01-05T22:00:00Z",
+    "unitCode": "KMH"
+  },
+  "location": {
+    "type": "GeoProperty",
+    "value": {
+      "type": "Point",
+      "coordinates": [
+        0.0,
+        0.0
+      ]
+    }
+  },
+  "atmosphericPressure": [
+    {
+      "type": "Property",
+      "datasetId": "urn:ngsi-ld:Dataset:WeatherApi",
+      "observedBy": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:Device:WeatherApi:ea7dabee-918a-4482-bcbc-223bc0d5d4c0"
+      },
+      "value": 1010,
+      "observedAt": "2022-01-06T08:45:00Z",
+      "unitCode": "MBR"
+    },
+    {
+      "type": "Property",
+      "datasetId": "urn:ngsi-ld:Dataset:WeatherStation",
+      "observedBy": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:Device:WeatherStation:dc94e9f5-6e3a-443d-88b4-778d2519b3c6"
+      },
+      "value": 998,
+      "observedAt": "2022-01-05T23:00:00Z",
+      "unitCode": "MBR"
+    }
+  ],
+  "cloud": {
+    "type": "Property",
+    "datasetId": "urn:ngsi-ld:Dataset:WeatherApi",
+    "observedBy": {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:Device:WeatherApi:ea7dabee-918a-4482-bcbc-223bc0d5d4c0"
+    },
+    "value": 100,
+    "observedAt": "2022-01-06T08:45:00Z",
+    "unitCode": "P1"
+  },
+  "dewPoint": {
+    "type": "Property",
+    "datasetId": "urn:ngsi-ld:Dataset:WeatherStation",
+    "observedBy": {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:Device:WeatherStation:dc94e9f5-6e3a-443d-88b4-778d2519b3c6"
+    },
+    "value": 8.8,
+    "observedAt": "2022-01-05T23:00:00Z",
+    "unitCode": "CEL"
+  },
+  "precipitation": [
+    {
+      "type": "Property",
+      "datasetId": "urn:ngsi-ld:Dataset:WeatherApi",
+      "observedBy": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:Device:WeatherApi:ea7dabee-918a-4482-bcbc-223bc0d5d4c0"
+      },
+      "value": 0.2,
+      "observedAt": "2022-01-06T08:45:00Z",
+      "unitCode": "MM"
+    },
+    {
+      "type": "Property",
+      "datasetId": "urn:ngsi-ld:Dataset:WeatherStation",
+      "observedBy": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:Device:WeatherStation:dc94e9f5-6e3a-443d-88b4-778d2519b3c6"
+      },
+      "value": 1.2,
+      "observedAt": "2022-01-05T23:00:00Z",
+      "unitCode": "MM"
+    }
+  ],
+  "relativeHumidity": [
+    {
+      "type": "Property",
+      "datasetId": "urn:ngsi-ld:Dataset:WeatherApi",
+      "observedBy": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:Device:WeatherApi:ea7dabee-918a-4482-bcbc-223bc0d5d4c0"
+      },
+      "value": 92,
+      "observedAt": "2022-01-06T08:45:00Z",
+      "unitCode": "P1"
+    },
+    {
+      "type": "Property",
+      "datasetId": "urn:ngsi-ld:Dataset:WeatherStation",
+      "observedBy": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:Device:WeatherStation:dc94e9f5-6e3a-443d-88b4-778d2519b3c6"
+      },
+      "value": 89.5,
+      "observedAt": "2022-01-05T23:00:00Z",
+      "unitCode": "P1"
+    }
+  ],
+  "temperature": [
+    {
+      "type": "Property",
+      "datasetId": "urn:ngsi-ld:Dataset:WeatherApi",
+      "observedBy": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:Device:WeatherApi:ea7dabee-918a-4482-bcbc-223bc0d5d4c0"
+      },
+      "value": 9.1,
+      "observedAt": "2022-01-06T08:45:00Z",
+      "unitCode": "CEL"
+    },
+    {
+      "type": "Property",
+      "datasetId": "urn:ngsi-ld:Dataset:WeatherStation",
+      "observedBy": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:Device:WeatherStation:dc94e9f5-6e3a-443d-88b4-778d2519b3c6"
+      },
+      "value": 10.5,
+      "observedAt": "2022-01-05T23:00:00Z",
+      "unitCode": "CEL"
+    }
+  ],
+  "uVIndexMax": {
+    "type": "Property",
+    "datasetId": "urn:ngsi-ld:Dataset:WeatherApi",
+    "observedBy": {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:Device:WeatherApi:ea7dabee-918a-4482-bcbc-223bc0d5d4c0"
+    },
+    "value": 2,
+    "observedAt": "2022-01-06T08:45:00Z"
+  },
+  "visibility": {
+    "type": "Property",
+    "datasetId": "urn:ngsi-ld:Dataset:WeatherApi",
+    "observedBy": {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:Device:WeatherApi:ea7dabee-918a-4482-bcbc-223bc0d5d4c0"
+    },
+    "value": 10,
+    "observedAt": "2022-01-06T08:45:00Z",
+    "unitCode": "KM"
+  },
+  "windDirection": [
+    {
+      "type": "Property",
+      "datasetId": "urn:ngsi-ld:Dataset:WeatherStation",
+      "observedBy": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:Device:WeatherStation:dc94e9f5-6e3a-443d-88b4-778d2519b3c6"
+      },
+      "value": 0,
+      "observedAt": "2022-01-05T23:00:00Z",
+      "unitCode": "DEG"
+    },
+    {
+      "type": "Property",
+      "datasetId": "urn:ngsi-ld:Dataset:WeatherApi",
+      "observedBy": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:Device:WeatherApi:ea7dabee-918a-4482-bcbc-223bc0d5d4c0"
+      },
+      "value": 204,
+      "observedAt": "2022-01-06T08:45:00Z",
+      "unitCode": "DEG"
+    }
+  ],
+  "windSpeed": [
+    {
+      "type": "Property",
+      "datasetId": "urn:ngsi-ld:Dataset:WeatherStation",
+      "observedBy": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:Device:WeatherStation:dc94e9f5-6e3a-443d-88b4-778d2519b3c6"
+      },
+      "value": 0,
+      "observedAt": "2022-01-05T23:00:00Z",
+      "unitCode": "KMH"
+    },
+    {
+      "type": "Property",
+      "datasetId": "urn:ngsi-ld:Dataset:WeatherApi",
+      "observedBy": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:Device:WeatherApi:ea7dabee-918a-4482-bcbc-223bc0d5d4c0"
+      },
+      "value": 6.8,
+      "observedAt": "2022-01-06T08:45:00Z",
+      "unitCode": "KMH"
+    }
+  ],
+  "@context": [
+    "https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/weather/jsonld-contexts/weather-compound.jsonld"
+  ]
+}

--- a/weather/ngsild-payloads/weatherObserved-multiple-sources.json
+++ b/weather/ngsild-payloads/weatherObserved-multiple-sources.json
@@ -12,49 +12,74 @@
     "observedAt": "2022-01-05T23:00:00Z",
     "unitCode": "E92"
   },
-  "relativeHumidity80": {
-    "type": "Property",
-    "datasetId": "urn:ngsi-ld:Dataset:WeatherStation",
-    "observedBy": {
-      "type": "Relationship",
-      "object": "urn:ngsi-ld:Device:WeatherStation:dc94e9f5-6e3a-443d-88b4-778d2519b3c6"
+  "relativeHumidityOverThreshold": [
+    {
+      "type": "Property",
+      "datasetId": "urn:ngsi-ld:Dataset:WeatherStation:80",
+      "observedBy": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:Device:WeatherStation:dc94e9f5-6e3a-443d-88b4-778d2519b3c6"
+      },
+      "value": 180,
+      "observedAt": "2022-01-05T23:00:00Z",
+      "unitCode": "SEC",
+      "threshold": {
+        "type": "Property",
+        "value": 80,
+        "unitCode": "P1"
+      },
+      "timeWindow": {
+        "type": "Property",
+        "value": 3600,
+        "unitCode": "SEC"
+      }
     },
-    "value": 180,
-    "observedAt": "2022-01-05T23:00:00Z",
-    "unitCode": "SEC"
-  },
-  "relativeHumidity90": {
-    "type": "Property",
-    "datasetId": "urn:ngsi-ld:Dataset:WeatherStation",
-    "observedBy": {
-      "type": "Relationship",
-      "object": "urn:ngsi-ld:Device:WeatherStation:dc94e9f5-6e3a-443d-88b4-778d2519b3c6"
-    },
-    "value": 144,
-    "observedAt": "2022-01-05T23:00:00Z",
-    "unitCode": "SEC"
-  },
-  "windAverage1mn": {
-    "type": "Property",
-    "datasetId": "urn:ngsi-ld:Dataset:WeatherStation",
-    "observedBy": {
-      "type": "Relationship",
-      "object": "urn:ngsi-ld:Device:WeatherStation:dc94e9f5-6e3a-443d-88b4-778d2519b3c6"
-    },
-    "value": 0,
-    "observedAt": "2022-01-05T22:00:00Z",
-    "unitCode": "KMH"
-  },
-  "location": {
-    "type": "GeoProperty",
-    "value": {
-      "type": "Point",
-      "coordinates": [
-        0.0,
-        0.0
-      ]
+    {
+      "type": "Property",
+      "datasetId": "urn:ngsi-ld:Dataset:WeatherStation:90",
+      "observedBy": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:Device:WeatherStation:dc94e9f5-6e3a-443d-88b4-778d2519b3c6"
+      },
+      "value": 144,
+      "observedAt": "2022-01-05T23:00:00Z",
+      "unitCode": "SEC",
+      "threshold": {
+        "type": "Property",
+        "value": 90,
+        "unitCode": "P1"
+      },
+      "timeWindow": {
+        "type": "Property",
+        "value": 3600,
+        "unitCode": "SEC"
+      }
     }
-  },
+  ],
+  "windMaxAverage": [
+    {
+      "type": "Property",
+      "datasetId": "urn:ngsi-ld:Dataset:WeatherStation",
+      "observedBy": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:Device:WeatherStation:dc94e9f5-6e3a-443d-88b4-778d2519b3c6"
+      },
+      "value": 15,
+      "observedAt": "2022-01-05T23:00:00Z",
+      "unitCode": "KMH",
+      "timeWindow": {
+        "type": "Property",
+        "value": 3600,
+        "unitCode": "SEC"
+      },
+      "averagedOn": {
+        "type": "Property",
+        "value": 60,
+        "unitCode": "SEC",
+        "observedAt": "2022-01-05T23:12:00Z"
+      }
+    }
+  ],
   "atmosphericPressure": [
     {
       "type": "Property",
@@ -238,7 +263,7 @@
         "object": "urn:ngsi-ld:Device:WeatherApi:ea7dabee-918a-4482-bcbc-223bc0d5d4c0"
       },
       "value": 6.8,
-      "observedAt": "2022-01-06T08:45:00Z",
+      "observedAt": "2022-01-05T23:00:00Z",
       "unitCode": "KMH"
     }
   ],

--- a/weather/ngsild-payloads/weatherObserved-weatherAPI.json
+++ b/weather/ngsild-payloads/weatherObserved-weatherAPI.json
@@ -1,0 +1,119 @@
+{
+    "id": "urn:ngsi-ld:WeatherObserved:Hungary:Bacs-Kiskun:Kecskemet",
+    "type": "WeatherObserved",
+    "location": {
+      "type": "GeoProperty",
+      "value": {
+        "type": "Point",
+        "coordinates": [
+          0.0,
+          0.0
+        ]
+      }
+    },
+    "atmosphericPressure": {
+      "type": "Property",
+      "datasetId": "urn:ngsi-ld:Dataset:WeatherApi",
+      "observedBy": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:Device:WeatherApi:d3ca8f9e-c341-48a5-9b5a-f9811ea4c9c6"
+      },
+      "value": 1011,
+      "observedAt": "2022-01-06T08:30:00Z",
+      "unitCode": "MBR"
+    },
+    "cloud": {
+      "type": "Property",
+      "datasetId": "urn:ngsi-ld:Dataset:WeatherApi",
+      "observedBy": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:Device:WeatherApi:d3ca8f9e-c341-48a5-9b5a-f9811ea4c9c6"
+      },
+      "value": 0,
+      "observedAt": "2022-01-06T08:30:00Z",
+      "unitCode": "P1"
+    },
+    "dataProvider": {
+      "type": "Property",
+      "value": "http://api.weatherapi.com/"
+    },
+    "precipitation": {
+      "type": "Property",
+      "datasetId": "urn:ngsi-ld:Dataset:WeatherApi",
+      "observedBy": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:Device:WeatherApi:d3ca8f9e-c341-48a5-9b5a-f9811ea4c9c6"
+      },
+      "value": 0,
+      "observedAt": "2022-01-06T08:30:00Z",
+      "unitCode": "MM"
+    },
+    "relativeHumidity": {
+      "type": "Property",
+      "datasetId": "urn:ngsi-ld:Dataset:WeatherApi",
+      "observedBy": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:Device:WeatherApi:d3ca8f9e-c341-48a5-9b5a-f9811ea4c9c6"
+      },
+      "value": 65,
+      "observedAt": "2022-01-06T08:30:00Z",
+      "unitCode": "P1"
+    },
+    "temperature": {
+      "type": "Property",
+      "datasetId": "urn:ngsi-ld:Dataset:WeatherApi",
+      "observedBy": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:Device:WeatherApi:d3ca8f9e-c341-48a5-9b5a-f9811ea4c9c6"
+      },
+      "value": 4,
+      "observedAt": "2022-01-06T08:30:00Z",
+      "unitCode": "CEL"
+    },
+    "uVIndexMax": {
+      "type": "Property",
+      "datasetId": "urn:ngsi-ld:Dataset:WeatherApi",
+      "observedBy": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:Device:WeatherApi:d3ca8f9e-c341-48a5-9b5a-f9811ea4c9c6"
+      },
+      "value": 2,
+      "observedAt": "2022-01-06T08:30:00Z"
+    },
+    "visibility": {
+      "type": "Property",
+      "datasetId": "urn:ngsi-ld:Dataset:WeatherApi",
+      "observedBy": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:Device:WeatherApi:d3ca8f9e-c341-48a5-9b5a-f9811ea4c9c6"
+      },
+      "value": 10,
+      "observedAt": "2022-01-06T08:30:00Z",
+      "unitCode": "KM"
+    },
+    "windDirection": {
+      "type": "Property",
+      "datasetId": "urn:ngsi-ld:Dataset:WeatherApi",
+      "observedBy": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:Device:WeatherApi:d3ca8f9e-c341-48a5-9b5a-f9811ea4c9c6"
+      },
+      "value": 290,
+      "observedAt": "2022-01-06T08:30:00Z",
+      "unitCode": "DEG"
+    },
+    "windSpeed": {
+      "type": "Property",
+      "datasetId": "urn:ngsi-ld:Dataset:WeatherApi",
+      "observedBy": {
+        "type": "Relationship",
+        "object": "urn:ngsi-ld:Device:WeatherApi:d3ca8f9e-c341-48a5-9b5a-f9811ea4c9c6"
+      },
+      "value": 25.9,
+      "observedAt": "2022-01-06T08:30:00Z",
+      "unitCode": "KMH"
+    },
+    "@context": [
+      "https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/weather/jsonld-contexts/weather-compound.jsonld"
+    ]
+  }


### PR DESCRIPTION
Adding a weather context, specific to weather attributes/vocabularies, that can (should!) be reused in any project/domain that needs it.
It is made up of a specific weather.jsonld contexts file that contains terms that are not already present into contexts `https://fiware.github.io/data-models/context.jsonld` and `https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld`, and a weather-compound.jsonld contexts file, which is the one to use.

resolve #82 