### PR TITLE
add context for GRACED use cases

### DIFF
--- a/graced/jsonld-contexts/README.md
+++ b/graced/jsonld-contexts/README.md
@@ -1,0 +1,10 @@
+# Context files for GRACED
+This context aims to contain all terms used for all the Graced use cases (**Pilze**, **Tecnoalimenti (TCA)**, **Sous les fraises (SLF)** and **Pour l'agriculture du vivan (PADV)**).
+
+It contains:
+* context file **agrifood** (https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/agrifood/jsonld-contexts/agrifood-compound.jsonld)
+* context file **weather** (https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/weather/jsonld-contexts/weather-compound.jsonld)
+
+Which support **Pilze** and **TCA** use cases.
+
+Additional contexts will be added in due time for **SLF** and **PADV**.

--- a/graced/jsonld-contexts/README.md
+++ b/graced/jsonld-contexts/README.md
@@ -2,8 +2,8 @@
 This context aims to contain all terms used for all the Graced use cases (**Pilze**, **Tecnoalimenti (TCA)**, **Sous les fraises (SLF)** and **Pour l'agriculture du vivan (PADV)**).
 
 It contains:
-* context file **agrifood** (https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/agrifood/jsonld-contexts/agrifood-compound.jsonld)
-* context file **weather** (https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/weather/jsonld-contexts/weather-compound.jsonld)
+* context file for **agrifood** domain defined in https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/agrifood/jsonld-contexts/agrifood-compound.jsonld
+* context file for **weather** domain defined in https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/weather/jsonld-contexts/weather-compound.jsonld
 
 Which support **Pilze** and **TCA** use cases.
 

--- a/graced/jsonld-contexts/graced.jsonld
+++ b/graced/jsonld-contexts/graced.jsonld
@@ -1,0 +1,6 @@
+{
+    "@context": [
+        "https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/agrifood/jsonld-contexts/agrifood-compound.jsonld",
+        "https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/weather/jsonld-contexts/weather-compound.jsonld"
+    ]
+}

--- a/graced/jsonld-contexts/graced.jsonld
+++ b/graced/jsonld-contexts/graced.jsonld
@@ -1,6 +1,11 @@
 {
     "@context": [
-        "https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/agrifood/jsonld-contexts/agrifood-compound.jsonld",
-        "https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/weather/jsonld-contexts/weather-compound.jsonld"
+        "https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/agrifood/jsonld-contexts/agrifood.jsonld",
+        "https://raw.githubusercontent.com/smart-data-models/dataModel.Agrifood/master/context.jsonld",
+        "https://raw.githubusercontent.com/smart-data-models/dataModel.Device/master/context.jsonld",
+        "https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/weather/jsonld-contexts/weather.jsonld",
+        "https://raw.githubusercontent.com/smart-data-models/dataModel.Environment/master/context.jsonld",
+        "https://raw.githubusercontent.com/smart-data-models/dataModel.Weather/master/context.jsonld",
+        "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ]
 }


### PR DESCRIPTION
A context for all GRACED use cases.
Currently contains weather, agrifood contexts for TCA & Pilze use cases. Will be updated in due time for SLF.