### PR TITLE
correct loraSNR typo and change URL path to dataModel.Device

### DIFF
--- a/device/jsonld-contexts/device.jsonld
+++ b/device/jsonld-contexts/device.jsonld
@@ -1,6 +1,6 @@
 {
     "@context": {
-        "batteryVoltage": "https://uri.fiware.org/ns/data-models#batteryVoltage",
-        "loraSNR": "https://uri.fiware.org/ns/data-models#loraSnr"
+        "batteryVoltage": "https://smartdatamodels.org/dataModel.Device/batteryVoltage",
+        "loraSNR": "https://smartdatamodels.org/dataModel.Device/loraSNR"
     }
 } 


### PR DESCRIPTION
* Correct typo loraSnr -> loraSNR
* Update the context path to https://smartdatamodels.org/dataModel.Device/ (to be ready to pull request to smart data model Device ...)