### PR TITLE
Issue 93

### DIFF
--- a/graced/jsonld-contexts/graced.jsonld
+++ b/graced/jsonld-contexts/graced.jsonld
@@ -7,6 +7,9 @@
         "https://raw.githubusercontent.com/smart-data-models/dataModel.Environment/master/context.jsonld",
         "https://raw.githubusercontent.com/smart-data-models/dataModel.Weather/master/context.jsonld",
         "https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/device/jsonld-contexts/device.jsonld",
+        "https://raw.githubusercontent.com/easy-global-market/ngsild-api-data-models/master/water/jsonld-contexts/water.jsonld",
+        "https://raw.githubusercontent.com/smart-data-models/dataModel.WasteWater/master/context.jsonld",
+        "https://raw.githubusercontent.com/smart-data-models/dataModel.WaterQuality/master/context.jsonld",
         "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld"
     ]
 }

--- a/water/jsonld-contexts/water.jsonld
+++ b/water/jsonld-contexts/water.jsonld
@@ -1,0 +1,13 @@
+{
+    "@context": {
+        "WaterTreatmentTank": "https://smartdatamodels.org/dataModel.WasteWater/WaterTreatmentTank",
+        "WaterBeingTreated": "https://smartdatamodels.org/dataModel.WasteWater/WaterBeingTreated",
+        "hasWaterBeingTreated": "https://smartdatamodels.org/dataModel.WasteWater/hasWaterBeingTreated",
+        "hasWaterTreatmentTank": "https://smartdatamodels.org/dataModel.WasteWater/hasWaterTreatmentTank",
+        "waterIn": "https://smartdatamodels.org/dataModel.WasteWater/waterIn",
+        "waterOut": "https://smartdatamodels.org/dataModel.WasteWater/waterOut",
+        "tankCapacity": "https://smartdatamodels.org/dataModel.WasteWater/tankCapacity",
+        "treatmentCycle": "https://smartdatamodels.org/dataModel.WasteWater/treatmentCycle",
+        "ecoli": "https://smartdatamodels.org/dataModel.WaterQuality/ecoli"
+    }
+}


### PR DESCRIPTION
* A water context has been created in https://github.com/easy-global-market/ngsild-api-data-models, which contains terms used for the SLF water treatment through green wall use case and that are "*missing*" from the waterQuality or wasteWater smartdata contexts.
* The water context has been added to the graced context.

resolve #93 