### PR TITLE
Update weather.jsonld

### DIFF
--- a/weather/jsonld-contexts/weather.jsonld
+++ b/weather/jsonld-contexts/weather.jsonld
@@ -16,8 +16,15 @@
         "relativeHumidityOverThreshold": "https://uri.fiware.org/ns/data-models#relativeHumidityOverThreshold",
         "sensibleWeatherId": "https://uri.fiware.org/ns/data-models#sensibleWeatherId",
         "vapourPressureDeficit": "https://uri.fiware.org/ns/data-models#vapourPressureDeficit",
-        "visibility": "https://uri.fiware.org/ns/data-models#visibility",
+        "windMaxAverage": "https://uri.fiware.org/ns/data-models#windMaxAverage",
+        "atmosphericPressure": "https://smartdatamodels.org/dataModel.Weather/atmosphericPressure",
+        "gustSpeed": "https://smartdatamodels.org/dataModel.Weather/gustSpeed",
+        "refPointOfInterest": "https://smartdatamodels.org/dataModel.Weather/refPointOfInterest",
+        "visibility": "https://smartdatamodels.org/dataModel.Weather/visibility",
         "weatherCode": "https://smartdatamodels.org/dataModel.Weather/weatherCode",
-        "windMaxAverage": "https://uri.fiware.org/ns/data-models#windMaxAverage"
+        "wavePeriod": "https://smartdatamodels.org/dataModel.Weather/wavePeriod",
+        "weatherType": "https://smartdatamodels.org/dataModel.Weather/weatherType",
+        "windDirection": "https://smartdatamodels.org/dataModel.Weather/windDirection",
+        "windSpeed": "https://smartdatamodels.org/dataModel.Weather/windSpeed"
     }
 }


### PR DESCRIPTION
some attributes were removed from smart-data-models, I add them here while waiting that they fix that
visibility was already in this context with a different expanded name ...
I'm forced to replace by the new one for my processes to work. It will cause an issue if something somewhere was using only weather.jsonld and not the one from smart-data-models (or if there is a compound where weather.jsonld is prioritary on the one from smart-data-models) but i doubt it is the case somewhere.
