### PR TITLE
feat: viewedBy attribute to authorization entity for historical data

### DIFF
--- a/openIt/jsonld-contexts/openIt.jsonld
+++ b/openIt/jsonld-contexts/openIt.jsonld
@@ -22,6 +22,7 @@
     "usesKey": "https://vocab.egm.io/usesKey",
     "validationStatus": "https://vocab.egm.io/validationStatus",
     "validityEndDate": "https://vocab.egm.io/validityEndDate",
-    "validityStartDate": "https://vocab.egm.io/validityStartDate"
+    "validityStartDate": "https://vocab.egm.io/validityStartDate",
+    "viewedBy": "https://vocab.egm.io/viewedBy"
   }
 }

--- a/openIt/ngsild-payloads/authorization.jsonld
+++ b/openIt/ngsild-payloads/authorization.jsonld
@@ -78,5 +78,19 @@
   "generatedUntil": {
     "type": "Property",
     "value": "2024-09-02T23:59:59.000Z"
-  }
+  },
+  "viewedBy": [
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:UserProfile:123",
+      "datasetId": "urn:ngsi-ld:Dataset:2024-11-25-09-01-00-123",
+      "observedAt": "2024-11-25T09:01:00Z"
+    },
+    {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:UserProfile:123",
+      "datasetId": "urn:ngsi-ld:Dataset:2024-11-24-09-01-00-123",
+      "observedAt": "2024-11-24T09:01:00Z"
+    }
+  ]
 }

--- a/openIt/ngsild-payloads/authorization.jsonld
+++ b/openIt/ngsild-payloads/authorization.jsonld
@@ -79,16 +79,9 @@
     "type": "Property",
     "value": "2024-09-02T23:59:59.000Z"
   },
-  "viewedBy": [
-    {
-      "type": "Relationship",
-      "object": "urn:ngsi-ld:UserProfile:123",
-      "observedAt": "2024-11-25T09:01:00Z"
-    },
-    {
-      "type": "Relationship",
-      "object": "urn:ngsi-ld:UserProfile:123",
-      "observedAt": "2024-11-24T09:01:00Z"
-    }
-  ]
+  "viewedBy": {
+    "type": "Relationship",
+    "object": "urn:ngsi-ld:UserProfile:123",
+    "observedAt": "2024-11-25T09:01:00Z"
+  }
 }

--- a/openIt/ngsild-payloads/authorization.jsonld
+++ b/openIt/ngsild-payloads/authorization.jsonld
@@ -83,13 +83,11 @@
     {
       "type": "Relationship",
       "object": "urn:ngsi-ld:UserProfile:123",
-      "datasetId": "urn:ngsi-ld:Dataset:2024-11-25-09-01-00-123",
       "observedAt": "2024-11-25T09:01:00Z"
     },
     {
       "type": "Relationship",
       "object": "urn:ngsi-ld:UserProfile:123",
-      "datasetId": "urn:ngsi-ld:Dataset:2024-11-24-09-01-00-123",
       "observedAt": "2024-11-24T09:01:00Z"
     }
   ]


### PR DESCRIPTION
Added a "viewedBy" attribute to the authorization entity. To keep historical data of which user viewed the code, this temporal data will be stored here.