### PR TITLE
Update smartParking.jsonld

### DIFF
--- a/smartParking/jsonld-contexts/smartParking.jsonld
+++ b/smartParking/jsonld-contexts/smartParking.jsonld
@@ -19,6 +19,7 @@
         "vtype": "https://uri.fiware.org/ns/data-models#vtype",
         "pfisc": "https://uri.fiware.org/ns/data-models#pfisc",
         "carrosserie": "https://uri.fiware.org/ns/data-models#carrosserie",
-        "curStay": "https://uri.fiware.org/ns/data-models#curStay"
+        "curStay": "https://uri.fiware.org/ns/data-models#curStay",
+        "occupied": "https://vocab.egm.io/occupied"
     }
 }


### PR DESCRIPTION
Needed for TPS 100 measurement ("occupied" is the only retrieved attribute for now apparently)