### PR TITLE
feat(TP): add irrelevantModules term to config

### DIFF
--- a/twinPicks/jsonld-contexts/usecase.jsonld
+++ b/twinPicks/jsonld-contexts/usecase.jsonld
@@ -10,6 +10,7 @@
     "description": "http://purl.org/dc/terms/description",
     "externalLinks": "https://vocab.egm.io/externalLinks",
     "imgSource": "https://vocab.egm.io/imgSource",
+    "irrelevantModules": "https://vocab.egm.io/irrelevantModules",
     "name": "https://schema.org/name",
     "refConfig": "https://vocab.egm.io/refConfig"
   }

--- a/twinPicks/ngsild-payloads/useCaseConfig.jsonld
+++ b/twinPicks/ngsild-payloads/useCaseConfig.jsonld
@@ -21,6 +21,17 @@
         "type": "Property",
         "value": "irrigationIcon"
     },
+    "irrelevantModules": {
+        "description": {
+            "type": "Property",
+            "value": "Optional property. Modules listed here won't appear in Twin.Picks when a use case of this type is selected"
+        },
+        "type": "Property",
+        "value": [
+            "trafficVisualization",
+            "serverManagement"
+        ]
+    },
     "specificAccessPolicy": {
         "type": "Property",
         "value": "AUTH_READ"

--- a/twinPicks/ngsild-payloads/useCaseConfig.jsonld
+++ b/twinPicks/ngsild-payloads/useCaseConfig.jsonld
@@ -24,7 +24,7 @@
     "irrelevantModules": {
         "description": {
             "type": "Property",
-            "value": "Optional property. Modules listed here won't appear in Twin.Picks when a use case of this type is selected"
+            "value": "Optional property. Modules listed here won't appear in Twin·Picks when a use case of this type is selected"
         },
         "type": "Property",
         "value": [


### PR DESCRIPTION
Today it works with a json config in the front-end. It makes more sense to configure it from the use case config entity.