### PR TITLE
add maritimeTraffic context

### DIFF
--- a/maritimeTraffic/jsonld-contexts/maritimeTraffic-compound.jsonld
+++ b/maritimeTraffic/jsonld-contexts/maritimeTraffic-compound.jsonld
@@ -1,0 +1,6 @@
+{
+    "@context": [
+        "https://easy-global-market.github.io/ngsild-api-data-models/maritimeTraffic/jsonld-contexts/maritimeTraffic.jsonld",
+        "https://easy-global-market.github.io/ngsild-api-data-models/twinPicks/jsonld-contexts/twinPicks-compound.jsonld"
+    ]
+}

--- a/maritimeTraffic/jsonld-contexts/maritimeTraffic.jsonld
+++ b/maritimeTraffic/jsonld-contexts/maritimeTraffic.jsonld
@@ -1,0 +1,18 @@
+{
+    "@context": {
+        "Station": "https://vocab.egm.io/Station",
+        "Vessel": "https://vocab.egm.io/Vessel",
+        "callsign": "https://vocab.egm.io/callsign",
+        "courseOverGround": "https://vocab.egm.io/courseOverGround",
+        "destination": "https://vocab.egm.io/destination",
+        "draught": "https://vocab.egm.io/draught",
+        "heading": "https://vocab.egm.io/heading",
+        "imo": "https://vocab.egm.io/imo",
+        "mmsi": "https://vocab.egm.io/mmsi",
+        "navigationStatus": "https://vocab.egm.io/navigationStatus",
+        "positionAccuracy": "https://vocab.egm.io/positionAccuracy",
+        "rateOfTurn": "https://vocab.egm.io/rateOfTurn",
+        "speedOverGround": "https://vocab.egm.io/speedOverGround",
+        "vesselType": "https://vocab.egm.io/vesselType"
+    }
+}

--- a/maritimeTraffic/ngsild-payloads/vessel.jsonld
+++ b/maritimeTraffic/ngsild-payloads/vessel.jsonld
@@ -1,0 +1,73 @@
+{
+    "id": "urn:ngsi-ld:Vessel:227464540",
+    "type": "Vessel",
+    "mmsi": {
+        "type": "Property",
+        "value": 227464540
+    },
+    "imo": {
+        "type": "Property",
+        "value": 0
+    },
+    "name": {
+        "type": "Property",
+        "value": "AEROPORT DE NICE"
+    },
+    "callsign": {
+        "type": "Property",
+        "value": ""
+    },
+    "location": {
+        "type": "GeoProperty",
+        "value": {
+            "type": "Point",
+            "coordinates": [
+                7.17849,
+                43.65347
+            ]
+        },
+        "observedAt": "2025-02-24 13:51:58 GMT"
+    },
+    "courseOverGround": {
+        "type": "Property",
+        "value": 328.6,
+        "observedAt": "2025-02-24 13:51:58 GMT",
+        "unitCode": "DD",
+        "datasetId": "urn:ngsi-ld:Dataset:Raw"
+    },
+    "speedOverGround": {
+        "type": "Property",
+        "value": 21.8,
+        "observedAt": "2025-02-24 13:51:58 GMT",
+        "unitCode": "kn",
+        "datasetId": "urn:ngsi-ld:Dataset:Raw"
+    },
+    "heading": {
+        "type": "Property",
+        "value": 511,
+        "observedAt": "2025-02-24 13:51:58 GMT",
+        "datasetId": "urn:ngsi-ld:Dataset:Raw"
+    },
+    "rateOfTurn": {
+        "type": "Property",
+        "value": 128,
+        "observedAt": "2025-02-24 13:51:58 GMT",
+        "unitCode": "DDS",
+        "datasetId": "urn:ngsi-ld:Dataset:Raw"
+    },
+    "positionAccuracy": {
+        "type": "Property",
+        "value": 1,
+        "observedAt": "2025-02-24 13:51:58 GMT"
+    },
+    "navigationStatus": {
+        "type": "Property",
+        "value": 15,
+        "observedAt": "2025-02-24 13:51:58 GMT"
+    },
+    "destination": {
+        "type": "Property",
+        "value": "",
+        "observedAt": "2025-02-24 13:51:58 GMT"
+    }
+}


### PR DESCRIPTION
There is already a https://github.com/easy-global-market/ngsild-api-data-models/blob/master/vessel/jsonld-contexts/vessel.jsonld context, but it is not up to date with our current convention. Also I think "maritimeTraffic" is a more representative name than "vessel" for a usecase 

Needed for retrieving data from: https://www.aishub.net/api