### PR TITLE
Add DataPoint to weather context

### DIFF
--- a/weather/jsonld-contexts/weather.jsonld
+++ b/weather/jsonld-contexts/weather.jsonld
@@ -1,5 +1,6 @@
 {
     "@context": {
+        "DataPoint": "https://vocab.egm.io/DataPoint",
         "WeatherForcasted": "https://vocab.egm.io/WeatherForcasted",
         "WeatherInformation": "https://vocab.egm.io/WeatherInformation",
         "WeatherObserved": "https://vocab.egm.io/WeatherObserved",


### PR DESCRIPTION
Franck told me that I should not use "Distribution" for that, it should be added as double type if we decide we want it in the catalog (we might not want to) and for open data sharing