### PR TITLE
fix: simplify program duration

### DIFF
--- a/calendar/ngsild-payloads/program.jsonld
+++ b/calendar/ngsild-payloads/program.jsonld
@@ -33,5 +33,9 @@
   "soilDrainage": {
     "type": "Property",
     "value": true
+  },
+  "isActive": {
+    "type": "Property",
+    "value": false
   }
 }


### PR DESCRIPTION
Always in minutes to make it easier to parse for everyone since we don't need a complex duration system for this usecase.