### PR TITLE
feat: isCrisisKey added to Key entity

### DIFF
--- a/openIt/jsonld-contexts/openIt.jsonld
+++ b/openIt/jsonld-contexts/openIt.jsonld
@@ -15,6 +15,7 @@
     "givenTo": "https://vocab.egm.io/givenTo",
     "initDate": "https://vocab.egm.io/initDate",
     "isActive": "https://vocab.egm.io/isActive",
+    "isCrisisKey": "https://vocab.egm.io/isCrisisKey",
     "keyNumber": "https://vocab.egm.io/keyNumber",
     "name": "https://schema.org/name",
     "opensGate": "https://vocab.egm.io/opensGate",

--- a/openIt/ngsild-payloads/key.jsonld
+++ b/openIt/ngsild-payloads/key.jsonld
@@ -33,5 +33,9 @@
     "type": "Relationship",
     "object": "urn:ngsi-ld:UserProfile:123",
     "observedAt": "2024-11-25T09:01:00Z"
+  },
+  "isCrisisKey": {
+    "type": "Property",
+    "value": false
   }
 }


### PR DESCRIPTION
Added a new attribute called "isCrisisKey" to the Key entity. The purpose of this attribute is to be able to identify which keys are for crisis mode. This is not a key we want to be able to have as an option for standard authorizations, therefore this flag will help us filter it.