### PR TITLE
refactor: added a new usesKey to the crisis payload & updated id example

### DIFF
--- a/openIt/ngsild-payloads/crisis.jsonld
+++ b/openIt/ngsild-payloads/crisis.jsonld
@@ -1,5 +1,5 @@
 {
-  "id": "urn:ngsi-ld:Crisis:1234",
+  "id": "urn:ngsi-ld:Crisis:organization-name",
   "type": "Crisis",
   "name": {
     "type": "Property",
@@ -17,5 +17,9 @@
   "codeOfTheDay": {
     "type": "Property",
     "value": "123456"
+  },
+  "usesKey": {
+    "type": "Relationship",
+    "object": "urn:ngsi-ld:Key:1234"
   }
 }


### PR DESCRIPTION
I updated the payload to include the usesKey attribute for the relationship. I will need this information on the frontend to log who views the emergency keys.